### PR TITLE
update ROS dependencies to Python3

### DIFF
--- a/stage3_emlid/07-ros/01-packages
+++ b/stage3_emlid/07-ros/01-packages
@@ -1,5 +1,5 @@
-python-rosdep
-python-rosinstall-generator
-python-catkin-tools
-python-wstool
-python-rosinstall
+python3-rosdep
+python3-rosinstall-generator
+python3-catkin-tools
+python3-wstool
+python3-rosinstall

--- a/stage3_emlid/07-ros/01-packages
+++ b/stage3_emlid/07-ros/01-packages
@@ -1,5 +1,7 @@
 python3-rosdep
 python3-rosinstall-generator
 python3-catkin-tools
-python3-wstool
+python-wstool
 python3-rosinstall
+python3-osrf-pycommon
+python3-cffi


### PR DESCRIPTION
Since ROS Noetic is used, python-related packages should point to python3.

Cheers!